### PR TITLE
SELinux does not need to be disabled anymore

### DIFF
--- a/silverblue-v4l2loopback-module
+++ b/silverblue-v4l2loopback-module
@@ -102,14 +102,10 @@ load_v4l2loopback()
   echo "Loading v4l2loopback..."
 
   if ! lsmod |grep "v4l2loopback" &> /dev/null; then
-    # Ugly as hell
-    # https://github.com/containers/podman/issues/804
-    echo 0 > /sys/fs/selinux/enforce
     podman run --name v4l2loopback -e "V4L2LOOPBACK_VERSION=${V4L2LOOPBACK_VERSION}" \
     -e "V4L2LOOPBACK_KERNEL_VERSION=${V4L2LOOPBACK_KERNEL_VERSION}" --rm --privileged \
     ${V4L2LOOPBACK_IMAGE}:${V4L2LOOPBACK_IMAGETAG} \
     insmod /usr/lib/modules/${V4L2LOOPBACK_KERNEL_VERSION}/extra/v4l2loopback.ko exclusive_caps=1
-    echo 1 > /sys/fs/selinux/enforce
   fi
 }
 


### PR DESCRIPTION
The issue was fixed upstream, so we don't have to set enforce to 0 to be able to insert the module.